### PR TITLE
Fixed Bug #21: Now showing number_sold correctly

### DIFF
--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -62,7 +62,7 @@ class Product(SafeDeleteModel):
         for rating in ratings:
             total_rating += rating.rating
 
-        avg = total_rating / len(ratings)
+        avg = total_rating / len(ratings) if len(ratings) > 0 else "No Ratings Yet"
         return avg
 
     class Meta:

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -268,7 +268,7 @@ class Products(ViewSet):
 
         if number_sold is not None:
             def sold_filter(product):
-                if product.number_sold <= int(number_sold):
+                if product.number_sold >= int(number_sold):
                     return True
                 return False
 


### PR DESCRIPTION
## Changes

- updated `views/product.py` to show query string correctly. i.e. number_sold=2 should show items that have sold 2+ times

## Requests / Responses


Run GET for `products?number_sold=1` should show two items with number_sold showing 1 and 2, `products?number_sold=2` should just show 1 product that sold 2 times.

## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] Run in Postman GET seen above


## Related Issues

- Fixes #21 