### PR TITLE
Fixed #20: remove items from cart

### DIFF
--- a/bangazonapi/views/lineitem.py
+++ b/bangazonapi/views/lineitem.py
@@ -53,8 +53,6 @@ class LineItems(ViewSet):
             customer = Customer.objects.get(user=request.auth.user)
             line_item = OrderProduct.objects.get(pk=pk, order__customer=customer)
 
-            line_item.delete()
-
             serializer = LineItemSerializer(line_item, context={'request': request})
 
             return Response(serializer.data)

--- a/bangazonapi/views/lineitem.py
+++ b/bangazonapi/views/lineitem.py
@@ -53,6 +53,8 @@ class LineItems(ViewSet):
             customer = Customer.objects.get(user=request.auth.user)
             line_item = OrderProduct.objects.get(pk=pk, order__customer=customer)
 
+            line_item.delete()
+
             serializer = LineItemSerializer(line_item, context={'request': request})
 
             return Response(serializer.data)
@@ -77,6 +79,8 @@ class LineItems(ViewSet):
         try:
             customer = Customer.objects.get(user=request.auth.user)
             order_product = OrderProduct.objects.get(pk=pk, order__customer=customer)
+
+            order_product.delete()
 
             return Response({}, status=status.HTTP_204_NO_CONTENT)
 


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- Added `line_item.delete()` to `/views/lineitem.py` 

**Response**
In postman, run GET `/profile/cart` to see all items in cart. In separate tab, run DELETE for `/lineitems/6` you should receive a 204 No Content Response. Re-run the GET and confirm that lineitems object 6 is gone.
## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] Run the test mentioned above.


## Related Issues

- Fixes #20 
