### PR TITLE
Issue #18: All Payment Types being Returned

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -81,10 +81,10 @@ class Payments(ViewSet):
         """Handle GET requests to payment type resource"""
         payment_types = Payment.objects.all()
 
-        customer_id = self.request.query_params.get('customer', None)
+        customer = Customer.objects.get(user=request.auth.user)
 
-        if customer_id is not None:
-            payment_types = payment_types.filter(customer__id=customer_id)
+        if customer is not None:
+            payment_types = payment_types.filter(customer__id=customer.id)
 
         serializer = PaymentSerializer(
             payment_types, many=True, context={'request': request})


### PR DESCRIPTION
## Changes

- Changed `views/paymenttype.py`  `def list` to display just the paymenttypes of the logged in user.


**Response**

In Postman, run a GET for `http://localhost:8000/paymenttypes` It should only display one payment type, as opposed to initially showing all payment types.


## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] Run the above request in Postman


## Related Issues

- Fixes #18 