### PR TITLE
Ticket #14: filter by product location

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -250,6 +250,7 @@ class Products(ViewSet):
         order = self.request.query_params.get('order_by', None)
         direction = self.request.query_params.get('direction', None)
         number_sold = self.request.query_params.get('number_sold', None)
+        location_name = self.request.query_params.get('location_name', None)
 
         if order is not None:
             order_filter = order
@@ -273,6 +274,9 @@ class Products(ViewSet):
                 return False
 
             products = filter(sold_filter, products)
+
+        if location_name is not None:
+            products = products.filter(location__contains=location_name)
 
         serializer = ProductSerializer(
             products, many=True, context={'request': request})


### PR DESCRIPTION
## Changes

- Added filtering query string on `views/product.py` to filter by location


## Requests / Responses

**Request**
 In Postman, run GET on products for `http://localhost:8000/products?location_name=sant` ensure the location key on the response contains `sant` try other location_names and ensure those return locations that include that string.


## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] See request/response instructions above


## Related Issues

- Fixes #14 
