### PR TITLE
Ticket #13: Users can now favorite a seller

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -254,7 +254,7 @@ class Profile(ViewSet):
 
         return Response({}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
-    @action(methods=['get'], detail=False)
+    @action(methods=['get', 'post'], detail=False)
     def favoritesellers(self, request):
         """
         @api {GET} /profile/favoritesellers GET favorite sellers
@@ -302,13 +302,27 @@ class Profile(ViewSet):
                 }
             ]
         """
-        customer = Customer.objects.get(user=request.auth.user)
-        favorites = Favorite.objects.filter(customer=customer)
+        if request.method == 'GET':
+            customer = Customer.objects.get(user=request.auth.user)
+            favorites = Favorite.objects.filter(customer=customer)
 
-        serializer = FavoriteSerializer(
-            favorites, many=True, context={'request': request})
-        return Response(serializer.data)
+            serializer = FavoriteSerializer(
+                favorites, many=True, context={'request': request})
+            return Response(serializer.data)
 
+        if request.method == 'POST':
+            try:
+                new_favorite = Favorite()
+                new_favorite.seller = Customer.objects.get(id=request.data["seller"])
+                customer = Customer.objects.get(user=request.auth.user)
+                new_favorite.customer = customer
+                new_favorite.save()
+                serializer = FavoriteSerializer(
+                    new_favorite, many=False, context={'request': request})
+
+                return Response(serializer.data, status=status.HTTP_201_CREATED)
+            except Customer.DoesNotExist as ex:
+                return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
 
 class LineItemSerializer(serializers.HyperlinkedModelSerializer):
     """JSON serializer for products


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- Changed `views/product.py` `def favoritesellers` to have ability to GET and POST

## Requests / Responses

In Postman, run a GET for `http://localhost:8000/profile/favoritesellers`  In another tab, run a POST with the same URL. For the post body enter `{"seller": 7}` send the request. Re-run the GET and confirm that a new favorite was saved with an incremented PK and Seller if of 7

## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] Run request in postman explained above


## Related Issues

- Fixes #13 
