### PR TITLE
Ticket #9: Delete Payment Type Functional

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -56,8 +56,11 @@ class Payments(ViewSet):
             serializer = PaymentSerializer(
                 payment_type, context={'request': request})
             return Response(serializer.data)
+        except Payment.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+
         except Exception as ex:
-            return HttpResponseServerError(ex)
+            return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     def destroy(self, request, pk=None):
         """Handle DELETE requests for a single payment type

--- a/tests/payments.py
+++ b/tests/payments.py
@@ -1,7 +1,9 @@
+from bangazonapi import views
 import datetime
 import json
 from rest_framework import status
 from rest_framework.test import APITestCase
+from bangazonapi.models import payment
 
 
 class PaymentTests(APITestCase):
@@ -40,4 +42,18 @@ class PaymentTests(APITestCase):
         self.assertEqual(json_response["expiration_date"], "2024-12-31")
         self.assertEqual(json_response["create_date"], str(datetime.date.today()))
 
-    # TODO: Delete payment type
+
+    def test_delete_payment_type(self):
+        """
+        Ensure we can delete a payment type.
+        """
+        # Add product to order
+        self.test_create_payment_type()
+        url = "/paymenttypes/1"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # Get paymenttypes and verify paymenttype was removed
+        response = self.client.get(url) 
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/tests/payments.py
+++ b/tests/payments.py
@@ -1,9 +1,8 @@
-from bangazonapi import views
 import datetime
 import json
 from rest_framework import status
 from rest_framework.test import APITestCase
-from bangazonapi.models import payment
+from bangazonapi.models import Payment, Customer
 
 
 class PaymentTests(APITestCase):
@@ -47,8 +46,18 @@ class PaymentTests(APITestCase):
         """
         Ensure we can delete a payment type.
         """
+
         # Add product to order
-        self.test_create_payment_type()
+        #self.test_create_payment_type()
+        paymenttype = Payment()
+        paymenttype.merchant_name = "Chime"
+        paymenttype.account_number = "222-2222-2222"
+        paymenttype.expiration_date = "2030-01-01"
+        paymenttype.create_date = str(datetime.date.today())
+        paymenttype.customer_id = 1
+
+        paymenttype.save()
+
         url = "/paymenttypes/1"
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
         response = self.client.delete(url)


### PR DESCRIPTION
## Changes

- Updated `tests/payments.py` and `views/paymenttype.py` to make testing available for deleting payment types.

## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] Review code on`views/paymenttype.py` `def retrieve` and code on `tests/payments.py` `def test_delete_payment_type`. RUN in terminal `python3 manage.py test tests -v 1` ensure test comes back without errors


## Related Issues

- Fixes #9 
