### PR TITLE
Ticket #8: Delete Product Test Functional

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -154,8 +154,11 @@ class Products(ViewSet):
             product = Product.objects.get(pk=pk)
             serializer = ProductSerializer(product, context={'request': request})
             return Response(serializer.data)
+        except Product.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+
         except Exception as ex:
-            return HttpResponseServerError(ex)
+            return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     def update(self, request, pk=None):
         """

--- a/tests/product.py
+++ b/tests/product.py
@@ -95,6 +95,19 @@ class ProductTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(json_response), 3)
 
-    # TODO: Delete product
+    def test_delete_product(self):
+        """
+        Ensure we can delete a payment type.
+        """
+        # Add product to order
+        self.test_create_product()
+        url = "/products/1"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # Get products and verify product was removed
+        response = self.client.get(url) 
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     # TODO: Product can be rated. Assert average rating exists.


### PR DESCRIPTION
## Changes

- Updated `tests/product.py` and `views/product.py` to make testing available for deleting payment types.

## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] Review code on `views/product.py` `def retrieve` and code on `tests/product.py` `def test_delete_product`. RUN in terminal `python3 manage.py test tests -v 1` and ensure test comes back without errors


## Related Issues

- Fixes #8 
