### PR TITLE
Ticket #23: Bug keeps adding products to closed order

### DIFF
--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -104,7 +104,9 @@ class Orders(ViewSet):
         """
         customer = Customer.objects.get(user=request.auth.user)
         order = Order.objects.get(pk=pk, customer=customer)
-        order.payment_type = request.data["payment_type"]
+        payment = Payment.objects.get(pk=request.data["payment_type_id"])
+        order.payment_type = payment
+        
         order.save()
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -1,5 +1,6 @@
 """View module for handling requests about customer profiles"""
 import datetime
+from django.db.models.fields import NullBooleanField
 from django.http import HttpResponseServerError
 from django.contrib.auth.models import User
 from rest_framework import serializers, status
@@ -233,7 +234,7 @@ class Profile(ViewSet):
             """
 
             try:
-                open_order = Order.objects.get(customer=current_user)
+                open_order = Order.objects.get(customer=current_user, payment_type=None)
                 print(open_order)
             except Order.DoesNotExist as ex:
                 open_order = Order()


### PR DESCRIPTION
## Changes

- Changed `views/profile.py` line 237-238 to include `payment_type=None` in the the GET

## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] In Postman, create a new payment type using POST. Then, add a product to the cart by using a POST on `http://localhost:8000/profile/cart`. Next, Finish the order by sending a PUT request to the order's URL (i.e. the "url" key value you see in the get profile/cart. Finally, Add a product to the cart by sending a POST request to `http://localhost:8000/profile/cart`

Ensure the product is being related to a newly generated order instead of the completed order.

## Related Issues

- Fixes #23 
